### PR TITLE
Added standard-imghdr module for so builds compile cleaning OOB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx-rtd-theme
+standard-imghdr
 docutils==0.16


### PR DESCRIPTION
Currently, when following the instructions in the README the MAKE will fail missing the imghdr module. This fixes that error by including it in the requirements.txt file.